### PR TITLE
update to the latest major version of @testing-library/dom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@financial-times/accessible-autocomplete": "^2.1.2"
 			},
 			"devDependencies": {
-				"@testing-library/dom": "^7.31.2",
+				"@testing-library/dom": "^8.0.0",
 				"@testing-library/user-event": "^13.1.9",
 				"chai": "^4.3.4",
 				"eslint": "^7.26.0",
@@ -679,19 +679,19 @@
 			}
 		},
 		"node_modules/@jest/types": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
-			"integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+			"version": "27.0.6",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+			"integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
 			"dev": true,
 			"dependencies": {
 				"@types/istanbul-lib-coverage": "^2.0.0",
 				"@types/istanbul-reports": "^3.0.0",
 				"@types/node": "*",
-				"@types/yargs": "^15.0.0",
+				"@types/yargs": "^16.0.0",
 				"chalk": "^4.0.0"
 			},
 			"engines": {
-				"node": ">= 10.14.2"
+				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
 			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
@@ -757,9 +757,9 @@
 			}
 		},
 		"node_modules/@testing-library/dom": {
-			"version": "7.31.2",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.31.2.tgz",
-			"integrity": "sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.0.0.tgz",
+			"integrity": "sha512-Ym375MTOpfszlagRnTMO+FOfTt6gRrWiDOWmEnWLu9OvwCPOWtK6i5pBHmZ07wUJiQ7wWz0t8+ZBK2wFo2tlew==",
 			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.10.4",
@@ -769,10 +769,10 @@
 				"chalk": "^4.1.0",
 				"dom-accessibility-api": "^0.5.6",
 				"lz-string": "^1.4.4",
-				"pretty-format": "^26.6.2"
+				"pretty-format": "^27.0.2"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=12"
 			}
 		},
 		"node_modules/@testing-library/user-event": {
@@ -843,9 +843,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "15.12.4",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.4.tgz",
-			"integrity": "sha512-zrNj1+yqYF4WskCMOHwN+w9iuD12+dGm0rQ35HLl9/Ouuq52cEtd0CH9qMgrdNmi5ejC1/V7vKEXYubB+65DkA==",
+			"version": "15.12.5",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
+			"integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==",
 			"dev": true
 		},
 		"node_modules/@types/normalize-package-data": {
@@ -867,9 +867,9 @@
 			"dev": true
 		},
 		"node_modules/@types/yargs": {
-			"version": "15.0.13",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.13.tgz",
-			"integrity": "sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==",
+			"version": "16.0.3",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+			"integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
 			"dev": true,
 			"dependencies": {
 				"@types/yargs-parser": "*"
@@ -1183,9 +1183,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001239",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001239.tgz",
-			"integrity": "sha512-cyBkXJDMeI4wthy8xJ2FvDU6+0dtcZSJW3voUF8+e9f1bBeuvyZfc3PNbkOETyhbR+dGCPzn9E7MA3iwzusOhQ==",
+			"version": "1.0.30001241",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001241.tgz",
+			"integrity": "sha512-1uoSZ1Pq1VpH0WerIMqwptXHNNGfdl7d1cJUFs80CwQ/lVzdhTvsFZCeNFslze7AjsQnb4C85tzclPa1VShbeQ==",
 			"dev": true,
 			"funding": {
 				"type": "opencollective",
@@ -1332,9 +1332,9 @@
 			}
 		},
 		"node_modules/core-js-pure": {
-			"version": "3.15.1",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.15.1.tgz",
-			"integrity": "sha512-OZuWHDlYcIda8sJLY4Ec6nWq2hRjlyCqCZ+jCflyleMkVt3tPedDVErvHslyS2nbO+SlBFMSBJYvtLMwxnrzjA==",
+			"version": "3.15.2",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.15.2.tgz",
+			"integrity": "sha512-D42L7RYh1J2grW8ttxoY1+17Y4wXZeKe7uyplAI3FkNQyI5OgBIAjUfFiTPfL1rs0qLpxaabITNbjKl1Sp82tA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"funding": {
@@ -1591,9 +1591,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.3.757",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.757.tgz",
-			"integrity": "sha512-kP0ooyrvavDC+Y9UG6G/pUVxfRNM2VTJwtLQLvgsJeyf1V+7shMCb68Wj0/TETmfx8dWv9pToGkVT39udE87wQ==",
+			"version": "1.3.762",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.762.tgz",
+			"integrity": "sha512-LehWjRpfPcK8F1Lf/NZoAwWLWnjJVo0SZeQ9j/tvnBWYcT99qDqgo4raAfS2oTKZjPrR/jxruh85DGgDUmywEA==",
 			"dev": true
 		},
 		"node_modules/emoji-regex": {
@@ -2041,17 +2041,16 @@
 			"dev": true
 		},
 		"node_modules/fast-glob": {
-			"version": "3.2.5",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
-			"integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.6.tgz",
+			"integrity": "sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==",
 			"dev": true,
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
 				"@nodelib/fs.walk": "^1.2.3",
-				"glob-parent": "^5.1.0",
+				"glob-parent": "^5.1.2",
 				"merge2": "^1.3.0",
-				"micromatch": "^4.0.2",
-				"picomatch": "^2.2.1"
+				"micromatch": "^4.0.4"
 			},
 			"engines": {
 				"node": ">=8"
@@ -4013,18 +4012,30 @@
 			}
 		},
 		"node_modules/pretty-format": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
-			"integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+			"version": "27.0.6",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.6.tgz",
+			"integrity": "sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==",
 			"dev": true,
 			"dependencies": {
-				"@jest/types": "^26.6.2",
+				"@jest/types": "^27.0.6",
 				"ansi-regex": "^5.0.0",
-				"ansi-styles": "^4.0.0",
+				"ansi-styles": "^5.0.0",
 				"react-is": "^17.0.1"
 			},
 			"engines": {
-				"node": ">= 10"
+				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+			}
+		},
+		"node_modules/pretty-format/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
 		"node_modules/progress": {
@@ -6290,15 +6301,15 @@
 			"requires": {}
 		},
 		"@jest/types": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
-			"integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+			"version": "27.0.6",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+			"integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
 			"dev": true,
 			"requires": {
 				"@types/istanbul-lib-coverage": "^2.0.0",
 				"@types/istanbul-reports": "^3.0.0",
 				"@types/node": "*",
-				"@types/yargs": "^15.0.0",
+				"@types/yargs": "^16.0.0",
 				"chalk": "^4.0.0"
 			}
 		},
@@ -6348,9 +6359,9 @@
 			}
 		},
 		"@testing-library/dom": {
-			"version": "7.31.2",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.31.2.tgz",
-			"integrity": "sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.0.0.tgz",
+			"integrity": "sha512-Ym375MTOpfszlagRnTMO+FOfTt6gRrWiDOWmEnWLu9OvwCPOWtK6i5pBHmZ07wUJiQ7wWz0t8+ZBK2wFo2tlew==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.10.4",
@@ -6360,7 +6371,7 @@
 				"chalk": "^4.1.0",
 				"dom-accessibility-api": "^0.5.6",
 				"lz-string": "^1.4.4",
-				"pretty-format": "^26.6.2"
+				"pretty-format": "^27.0.2"
 			}
 		},
 		"@testing-library/user-event": {
@@ -6424,9 +6435,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "15.12.4",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.4.tgz",
-			"integrity": "sha512-zrNj1+yqYF4WskCMOHwN+w9iuD12+dGm0rQ35HLl9/Ouuq52cEtd0CH9qMgrdNmi5ejC1/V7vKEXYubB+65DkA==",
+			"version": "15.12.5",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
+			"integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -6448,9 +6459,9 @@
 			"dev": true
 		},
 		"@types/yargs": {
-			"version": "15.0.13",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.13.tgz",
-			"integrity": "sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==",
+			"version": "16.0.3",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+			"integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
 			"dev": true,
 			"requires": {
 				"@types/yargs-parser": "*"
@@ -6674,9 +6685,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001239",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001239.tgz",
-			"integrity": "sha512-cyBkXJDMeI4wthy8xJ2FvDU6+0dtcZSJW3voUF8+e9f1bBeuvyZfc3PNbkOETyhbR+dGCPzn9E7MA3iwzusOhQ==",
+			"version": "1.0.30001241",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001241.tgz",
+			"integrity": "sha512-1uoSZ1Pq1VpH0WerIMqwptXHNNGfdl7d1cJUFs80CwQ/lVzdhTvsFZCeNFslze7AjsQnb4C85tzclPa1VShbeQ==",
 			"dev": true
 		},
 		"chai": {
@@ -6785,9 +6796,9 @@
 			}
 		},
 		"core-js-pure": {
-			"version": "3.15.1",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.15.1.tgz",
-			"integrity": "sha512-OZuWHDlYcIda8sJLY4Ec6nWq2hRjlyCqCZ+jCflyleMkVt3tPedDVErvHslyS2nbO+SlBFMSBJYvtLMwxnrzjA==",
+			"version": "3.15.2",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.15.2.tgz",
+			"integrity": "sha512-D42L7RYh1J2grW8ttxoY1+17Y4wXZeKe7uyplAI3FkNQyI5OgBIAjUfFiTPfL1rs0qLpxaabITNbjKl1Sp82tA==",
 			"dev": true
 		},
 		"cosmiconfig": {
@@ -6985,9 +6996,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.757",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.757.tgz",
-			"integrity": "sha512-kP0ooyrvavDC+Y9UG6G/pUVxfRNM2VTJwtLQLvgsJeyf1V+7shMCb68Wj0/TETmfx8dWv9pToGkVT39udE87wQ==",
+			"version": "1.3.762",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.762.tgz",
+			"integrity": "sha512-LehWjRpfPcK8F1Lf/NZoAwWLWnjJVo0SZeQ9j/tvnBWYcT99qDqgo4raAfS2oTKZjPrR/jxruh85DGgDUmywEA==",
 			"dev": true
 		},
 		"emoji-regex": {
@@ -7357,17 +7368,16 @@
 			"dev": true
 		},
 		"fast-glob": {
-			"version": "3.2.5",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
-			"integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.6.tgz",
+			"integrity": "sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==",
 			"dev": true,
 			"requires": {
 				"@nodelib/fs.stat": "^2.0.2",
 				"@nodelib/fs.walk": "^1.2.3",
-				"glob-parent": "^5.1.0",
+				"glob-parent": "^5.1.2",
 				"merge2": "^1.3.0",
-				"micromatch": "^4.0.2",
-				"picomatch": "^2.2.1"
+				"micromatch": "^4.0.4"
 			}
 		},
 		"fast-json-stable-stringify": {
@@ -8820,15 +8830,23 @@
 			"dev": true
 		},
 		"pretty-format": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
-			"integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+			"version": "27.0.6",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.6.tgz",
+			"integrity": "sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^26.6.2",
+				"@jest/types": "^27.0.6",
 				"ansi-regex": "^5.0.0",
-				"ansi-styles": "^4.0.0",
+				"ansi-styles": "^5.0.0",
 				"react-is": "^17.0.1"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+					"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+					"dev": true
+				}
 			}
 		},
 		"progress": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 	"type": "module",
 	"browser": "main.js",
 	"devDependencies": {
-		"@testing-library/dom": "^7.31.2",
+		"@testing-library/dom": "^8.0.0",
 		"@testing-library/user-event": "^13.1.9",
 		"chai": "^4.3.4",
 		"eslint": "^7.26.0",

--- a/test/js/autocomplete.test.js
+++ b/test/js/autocomplete.test.js
@@ -1,6 +1,5 @@
 /* eslint-env mocha */
 /* global sinon */
-import './helpers/hack.js';
 import * as fixtures from './helpers/fixtures.js';
 import Autocomplete from '../../main.js';
 import { screen, getByRole } from '@testing-library/dom';

--- a/test/js/helpers/hack.js
+++ b/test/js/helpers/hack.js
@@ -1,7 +1,0 @@
-// This is required to make @testing-library/dom work.
-// @testing-library/dom depends on pretty-format and
-// pretty-format makes use of `global`...
-// -> Line 10 of https://unpkg.com/browse/pretty-format@27.0.2/build/plugins/AsymmetricMatcher.js
-// The line in the file above is `var Symbol = global['jest-symbol-do-not-touch'] || global.Symbol;`
-// This Pull-Request would fix the issue -- https://github.com/facebook/jest/pull/11569
-window.global = window;


### PR DESCRIPTION
We are not using any of the features which were removed or changed in the new version.

The new version also removes the need for the hack.js file we needed to use. The reason we needed that hack.js file was to work around an issue in a dependency of testing-library/dom called pretty-format. pretty-format's new version has fixed the [issue](https://github.com/facebook/jest/pull/11569) 