### PR TITLE
Make sure the clear button is associated with the correct input element

### DIFF
--- a/src/js/autocomplete.js
+++ b/src/js/autocomplete.js
@@ -78,7 +78,7 @@ function hideLoadingPane(instance) {
  */
 function createClearButton(id) {
 	const fragment = document.createRange().createContextualFragment(`
-		<button class="o-autocomplete__clear" type="button" aria-controls=${id} title="Clear input">
+		<button class="o-autocomplete__clear" type="button" aria-controls="${id}" title="Clear input">
 			<span class="o-autocomplete__visually-hidden">Clear input</span>
 		</button>
 	`);
@@ -91,9 +91,8 @@ function createClearButton(id) {
  * @returns {void}
  */
 function initClearButton(instance) {
-	const clearButton = createClearButton(instance.autocompleteEl.id);
-
 	const input = instance.autocompleteEl.querySelector('input');
+	const clearButton = createClearButton(input.id);
 	let timeout = null;
 	clearButton.addEventListener('click', () => {
 		// Remove the loading pane, in-case of a slow response.

--- a/test/js/autocomplete.test.js
+++ b/test/js/autocomplete.test.js
@@ -150,6 +150,8 @@ describe("Autocomplete", () => {
 					name: /clear input/i
 				});
 				assert.exists(clearButton);
+				// Check that the button is associated with the correct input
+				assert.equal(clearButton.getAttribute('aria-controls'), 'my-autocomplete');
 			});
 
 			it("shows the suggestion box with the filtered results", async () => {


### PR DESCRIPTION
Currently there is a bug where an empty string is being passed as the input ID for the clear button to be associated with.

This pull request fixes this bug and adds a test to check that the button's `aria-controls` attribute has the value of the input's ID.