### PR TITLE
Only allow specific options to be passed to accessible-autocomplete

### DIFF
--- a/src/js/autocomplete.js
+++ b/src/js/autocomplete.js
@@ -161,15 +161,11 @@ class Autocomplete {
 	constructor (autocompleteEl, options) {
 		this.autocompleteEl = autocompleteEl;
 
-		this.options = Object.assign({
-			placeholder: '',
-			cssNamespace: 'o-autocomplete',
-			displayMenu: 'overlay',
-			showNoOptionsFound: false,
-			templates: {
-				suggestion: this.suggestionTemplate.bind(this)
-			}
-		}, options || Autocomplete.getDataAttributes(autocompleteEl));
+		const opts = options || Autocomplete.getDataAttributes(autocompleteEl);
+		this.options = {};
+		if (opts.source) {
+			this.options.source = opts.source;
+		}
 
 		const container = document.createElement('div');
 		container.classList.add('o-autocomplete__listbox-container');
@@ -211,11 +207,18 @@ class Autocomplete {
 			}
 			this.autocompleteEl.innerHTML = '';
 			this.autocompleteEl.appendChild(this.container);
-			const options = Object.assign({
+			accessibleAutocomplete({
 				element: this.container,
 				id: id,
-			}, this.options);
-			accessibleAutocomplete(options);
+				source: this.options.source,
+				placeholder: '',
+				cssNamespace: 'o-autocomplete',
+				displayMenu: 'overlay',
+				showNoOptionsFound: false,
+				templates: {
+					suggestion: this.suggestionTemplate.bind(this)
+				}
+			});
 		} else {
 			const id = selectInputElement.getAttribute('id');
 			if (!id) {
@@ -223,12 +226,18 @@ class Autocomplete {
 			}
 			this.autocompleteEl.appendChild(this.container);
 			this.container.appendChild(selectInputElement);
-			const options = Object.assign({
+			accessibleAutocomplete.enhanceSelectElement({
 				selectElement: selectInputElement,
+				autoselect: false,
 				defaultValue: '',
-			}, this.options);
-			options.autoselect = false;
-			accessibleAutocomplete.enhanceSelectElement(options);
+				placeholder: '',
+				cssNamespace: 'o-autocomplete',
+				displayMenu: 'overlay',
+				showNoOptionsFound: false,
+				templates: {
+					suggestion: this.suggestionTemplate.bind(this)
+				}
+			});
 			selectInputElement.parentElement.removeChild(selectInputElement); // Remove the original select element
 		}
 
@@ -272,22 +281,14 @@ class Autocomplete {
 		if (!(autocompleteEl instanceof HTMLElement)) {
 			return {};
 		}
-		return Object.keys(autocompleteEl.dataset).reduce((options, key) => {
-			// Ignore keys which are not in the component's namespace
-			if (!key.match(/^oAutocomplete(\w)(\w+)$/)) {
-				return options;
-			}
-			// Build a concise key and get the option value
-			const shortKey = key.replace(/^oAutocomplete(\w)(\w+)$/, (m, m1, m2) => m1.toLowerCase() + m2);
-			const value = autocompleteEl.dataset[key];
-			// Try parsing the value as JSON, otherwise just set it as a string
-			try {
-				options[shortKey] = JSON.parse(value.replace(/'/g, '"'));
-			} catch (error) {
-				options[shortKey] = value;
-			}
-			return options;
-		}, {});
+
+		if (autocompleteEl.dataset.oAutocompleteSource) {
+			return {
+				source: autocompleteEl.dataset.oAutocompleteSource
+			};
+		} else {
+			return {};
+		}
 	}
 	/**
 	 * Initialise o-autocomplete component/s.

--- a/test/js/autocomplete.test.js
+++ b/test/js/autocomplete.test.js
@@ -75,10 +75,28 @@ describe("Autocomplete", () => {
 				const autocomplete = new Autocomplete(document.querySelector('[data-o-component="o-autocomplete"]'));
 				assert.instanceOf(autocomplete, Autocomplete);
 				assert.deepEqual(autocomplete.autocompleteEl, document.querySelector('[data-o-component="o-autocomplete"]'));
-				assert.equal(autocomplete.options.placeholder, '');
-				assert.equal(autocomplete.options.cssNamespace, 'o-autocomplete');
-				assert.equal(autocomplete.options.displayMenu, 'overlay');
-				assert.isFalse(autocomplete.options.showNoOptionsFound);
+			});
+		});
+
+		describe('only assigns options which are supported by o-autocomplete', () => {
+			beforeEach(() => {
+				fixtures.htmlSelectCode();
+			});
+
+			afterEach(() => {
+				fixtures.reset();
+			});
+			it('the unsupported options are not set on this.options', () => {
+				const autocomplete = new Autocomplete(document.querySelector('[data-o-component="o-autocomplete"]'), {
+					placeholder: 'Placeholder Text',
+					cssNamespace: 'custom-autocomplete',
+					displayMenu: 'whimsical',
+					showNoOptionsFound: "sometimes",
+					id: "hello"
+				});
+				assert.instanceOf(autocomplete, Autocomplete);
+
+				assert.deepEqual(autocomplete.options, {});
 			});
 		});
 
@@ -305,6 +323,48 @@ describe("Autocomplete", () => {
 
 		afterEach(() => {
 			fixtures.reset();
+		});
+
+		describe('only assigns options which are supported by o-autocomplete', () => {
+			beforeEach(() => {
+				fixtures.htmlInputCode();
+			});
+
+			afterEach(() => {
+				fixtures.reset();
+			});
+			it('the unsupported options are not set on this.options', () => {
+				const autocomplete = new Autocomplete(document.querySelector('[data-o-component="o-autocomplete"]'), {
+					placeholder: 'Placeholder Text',
+					cssNamespace: 'custom-autocomplete',
+					displayMenu: 'whimsical',
+					showNoOptionsFound: "sometimes",
+					id: "hello",
+					source: function customSuggestions(query, populateResults) {
+						const suggestions = [
+							'Origami',
+						];
+
+						if (!query) {
+							populateResults([]);
+							return;
+						}
+
+						const filteredResults = [];
+						for (const suggestion of suggestions) {
+							const lowercaseSuggestion = suggestion.toLocaleLowerCase();
+							if (lowercaseSuggestion.startsWith(query.toLocaleLowerCase())) {
+								filteredResults.push(suggestion);
+							}
+						}
+						populateResults(filteredResults);
+					}
+				});
+				assert.instanceOf(autocomplete, Autocomplete);
+
+				assert.deepEqual(Object.keys(autocomplete.options), ['source']);
+				assert.isFunction(autocomplete.options.source,);
+			});
 		});
 
 		context('synchronous source function', () => {


### PR DESCRIPTION
Right now we allow all options to be passed through by accident, we only document support for the `source` option though. We don't want to support all the options of accessible-autocomplete

To test this out fully I needed to add code to o-autocomplete which would allow the tests to spy on the `accessible-autocomplete` dependency that is imported. I did it using a privately exported object which has all the imported dependencies attached as properties. Having the dependencies exported privately means the tests can rely on this export but no consumers of o-autocomplete can.

I can't think of a way which doesn't modify the code, if there is a way, I'd like to use that instead if possible.