### PR TITLE
Add an onConfirm function which is called when the user selects an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,51 @@ new oAutocomplete(oAutocompleteElement, {
 | --- | --- | --- |
 | option | <code>\*</code> | The option to transform into a suggestion string |
 
+### onConfirm
+
+This function is called when the user selects an option and is called with the option the user selected.
+
+#### Example
+
+```js
+import oAutocomplete from 'o-autocomplete';
+
+async function customSuggestions(query, populateOptions) {
+	const suggestions = await getSuggestions(query);
+	populateOptions(suggestions);
+}
+
+/**
+ * @param {{"suggestionText": string}} option - The option to transform into a suggestion string
+ * @returns {string} The string to display as the suggestions for this option
+*/
+function mapOptionToSuggestedValue(option) {
+	return option.suggestionText;
+}
+
+/**
+ * @param {{"suggestionText": string}} option - The option the user selected
+*/
+function onConfirm(option) {
+    console.log('You selected option: ', option);
+}
+
+const oAutocompleteElement = document.getElementById('#my-o-autocomplete-element');
+new oAutocomplete(oAutocompleteElement, {
+    onConfirm
+    mapOptionToSuggestedValue,
+    source: customSuggestions,
+});
+```
+
+<a name="onConfirm"></a>
+
+#### onConfirm ⇒ <code>void</code>
+
+| Param | Type | Description |
+| --- | --- | --- |
+| option | <code>\*</code> | The option the user selected |
+
 
 ## Keyboard Support
 

--- a/demos/src/dynamic-complex/dynamic-complex.js
+++ b/demos/src/dynamic-complex/dynamic-complex.js
@@ -1,4 +1,4 @@
-import '../../../main.js';
+import Autocomplete from '../../../main.js';
 import {data} from './data.js';
 
 /**
@@ -16,11 +16,11 @@ import {data} from './data.js';
  * @param {CustomOption|undefined} option - The option to transform into a suggestion string
  * @returns {string} The string to display in the suggestions dropdown for this option
 */
-window.mapOptionToSuggestedValue = function mapOptionToSuggestedValue(option) {
+function mapOptionToSuggestedValue(option) {
 	if (option) {
 		return option.Country_Name;
 	}
-};
+}
 
 /**
  * @typedef {Function} PopulateOptions
@@ -32,7 +32,7 @@ window.mapOptionToSuggestedValue = function mapOptionToSuggestedValue(option) {
  * @param {PopulateOptions} populateOptions - Function to call when ready to update the suggestions dropdown
  * @returns {void}
  */
-window.customSuggestions = function customSuggestions(query, populateOptions) {
+function customSuggestions(query, populateOptions) {
 	const suggestions = data;
 
 	if (!query) {
@@ -51,8 +51,12 @@ window.customSuggestions = function customSuggestions(query, populateOptions) {
 		}
 	}
 	populateOptions(filteredOptions);
-};
+}
 
-document.addEventListener('DOMContentLoaded', function() {
-	document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
+new Autocomplete(document.querySelector('[data-o-component="o-autocomplete"]'), {
+	source: customSuggestions,
+	mapOptionToSuggestedValue,
+	onConfirm: function (option) {
+		console.log('You chose option', option);
+	}
 });

--- a/demos/src/dynamic-complex/dynamic-complex.mustache
+++ b/demos/src/dynamic-complex/dynamic-complex.mustache
@@ -4,7 +4,7 @@
             <span class="o-forms-title__main">Select your country</span>
         </span>
         <span class="o-forms-input o-forms-input--text">
-            <div data-o-component="o-autocomplete" data-o-autocomplete-source="customSuggestions" data-o-autocomplete-option-to-suggestion="mapOptionToSuggestedValue" class="o-autocomplete">
+            <div data-o-component="o-autocomplete" class="o-autocomplete">
                 <!-- If the JavaScript executes, then this input will be progressively enhanced to an autocomplete component -->
                 <input required type="text" name="text-example" id="my-autocomplete">
             </div>

--- a/src/js/autocomplete.js
+++ b/src/js/autocomplete.js
@@ -153,9 +153,16 @@ function initClearButton(instance) {
 */
 
 /**
+ * @callback onConfirm
+ * @param {*} option - The option the user selected
+ * @returns {void}
+*/
+
+/**
  * @typedef {Object} AutocompleteOptions
- * @property {Source} source - The function which retrieves the suggestions to display
- * @property {Function} [mapOptionToSuggestedValue] - Function which transforms a suggestion before rendering
+ * @property {Source} [source] - The function which retrieves the suggestions to display
+ * @property {MapOptionToSuggestedValue} [mapOptionToSuggestedValue] - Function which transforms a suggestion before rendering
+ * @property {onConfirm} [onConfirm] - Function which is called when the user selects an option
  */
 
 class Autocomplete {
@@ -174,6 +181,9 @@ class Autocomplete {
 		}
 		if (opts.mapOptionToSuggestedValue) {
 			this.options.mapOptionToSuggestedValue = opts.mapOptionToSuggestedValue;
+		}
+		if (opts.onConfirm) {
+			this.options.onConfirm = opts.onConfirm;
 		}
 
 		const container = document.createElement('div');
@@ -227,6 +237,11 @@ class Autocomplete {
 			accessibleAutocomplete({
 				element: this.container,
 				id: id,
+				onConfirm: (option) => {
+					if (option && this.options.onConfirm) {
+						this.options.onConfirm(option);
+					}
+				},
 				source: this.options.source,
 				placeholder: '',
 				cssNamespace: 'o-autocomplete',
@@ -290,6 +305,11 @@ class Autocomplete {
 			this.container.appendChild(selectInputElement);
 			accessibleAutocomplete.enhanceSelectElement({
 				selectElement: selectInputElement,
+				onConfirm: (option) => {
+					if (option && this.options.onConfirm) {
+						this.options.onConfirm(option);
+					}
+				},
 				autoselect: false,
 				defaultValue: '',
 				placeholder: '',


### PR DESCRIPTION
This function is useful to define when the options returned by the `source` function are not strings.
This is because the function is called with the selected option in it's original form. I.E. The option value which was returned by the `source` function before being passed through `mapOptionToSuggestedValue`.
